### PR TITLE
[BAC-414] Add mechanism in eks-orb to disable migration workflow

### DIFF
--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -180,24 +180,6 @@ steps:
         cat $ARGO_APP_VALUE_FILE
         echo "------------------------------------------------------"
 
-  - annotation:
-      app-name: << parameters.release-name >>
-      namespace: << parameters.namespace >>
-      resource-name: rollout
-      set-name: "kubernetes.io/previous-tag"
-      get-current-name: kubernetes\.io\/current-tag
-      set-path-annotation: << parameters.set-path-annotation >>
-      get-current-value: true
-      ignore-not-found: true
-
-  - annotation:
-      app-name: << parameters.release-name >>
-      namespace: << parameters.namespace >>
-      resource-name: rollout
-      set-name: "kubernetes.io/current-tag"
-      set-value: "<< parameters.image-tag >>"
-      ignore-not-found: true
-
   - run:
       name: Upsert Argo Application
       command: |

--- a/src/jobs/argo-deploy.yml
+++ b/src/jobs/argo-deploy.yml
@@ -85,13 +85,18 @@ parameters:
     type: string
     default: tiendanube
   # New parameters for ArgoCD migration workflow
-  migration-feedback-timeout:
+  argocd-migration-feedback-timeout:
     description: >
       The maximum time to wait for user feedback during the ArgoCD migration workflow (e.g. 1s, 2m, 3h).
       Must be a floating point number with an optional suffix: 's' for seconds (the default), 'm' for minutes, 'h' for hours or 'd' for days.
       A duration of 0 (the default) disables the associated timeout, in order to wait until the migration finishes.
     type: string
     default: '0'
+  argocd-migration-workflow-enabled:
+    description: >
+      Enable the ArgoCD migration workflow.
+    type: boolean
+    default: true
 
 steps:
   - run:
@@ -217,15 +222,18 @@ steps:
       profile-file-name: /tmp/environment-profile
       old-school-chart-file: /tmp/helm-detection/chart_name
 
-  - run:
-      name: Triggers the ArgoCD migration workflow
-      environment:
-        ROLLOUT_STATUS_TIMEOUT: << parameters.rollout-status-timeout >>
-        ROLLOUT_STATUS_COMMON_SCRIPT: << include(scripts/argo_rollout_status_common.sh) >>
-        ARGO_CLI_COMMON_SCRIPT: << include(scripts/argo_cli_common.sh) >>
-        FEEDBACK_TIMEOUT: << parameters.migration-feedback-timeout >>
-        FEEDBACK_ANNOTATION_KEY: migration.argocd.io/approval-next-phase
-        FEEDBACK_CHECK_INTERVAL: 10
-        ROLLOUT_STATUS_CHECK_INTERVAL: 10
-        PROFILE_FILE_NAME: /tmp/environment-profile
-      command: << include(scripts/argo_migration_workflow.sh) >>
+  - when:
+      condition: << parameters.argocd-migration-workflow-enabled >>
+      steps:
+        - run:
+            name: Triggers the ArgoCD migration workflow
+            environment:
+              ROLLOUT_STATUS_TIMEOUT: << parameters.rollout-status-timeout >>
+              ROLLOUT_STATUS_COMMON_SCRIPT: << include(scripts/argo_rollout_status_common.sh) >>
+              ARGO_CLI_COMMON_SCRIPT: << include(scripts/argo_cli_common.sh) >>
+              FEEDBACK_TIMEOUT: << parameters.argocd-migration-feedback-timeout >>
+              FEEDBACK_ANNOTATION_KEY: migration.argocd.io/approval-next-phase
+              FEEDBACK_CHECK_INTERVAL: 10
+              ROLLOUT_STATUS_CHECK_INTERVAL: 10
+              PROFILE_FILE_NAME: /tmp/environment-profile
+            command: << include(scripts/argo_migration_workflow.sh) >>


### PR DESCRIPTION
## Why? 🤔

We need this change because…

## What? :page_with_curl:

Please add a summary for this pull requests

## Additional Links 🔗

<!-- Add any relevant links here, eg. to other pull requests or Jira tickets.
NOTE: In case there aren't any, remove this section -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a toggle to enable/disable the ArgoCD migration workflow.
  - Added a configurable timeout for migration user feedback.

- Refactor
  - Stopped automatically setting rollout annotations for image tagging during deploys.

- Chores
  - Renamed parameter migration-feedback-timeout to argocd-migration-feedback-timeout (update your configurations).
  - Migration workflow now runs only when explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->