### PR TITLE
[BAC-414] Add mechanism in eks-orb to disable migration workflow (#41)

### DIFF
--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -67,11 +67,12 @@ steps:
         cat \<< 'EOF' > $PARAMETERS_CHART_DIR/templates/parameters.yaml
         {{- define "formatValue" -}}
         {{- $sentinelDollarEscaped := "::DOLLAR_ESCAPED::" -}}
+        {{- $sentinelNewlineEscaped := "::NEWLINE_ESCAPED::" -}}
         {{- $value := . -}}
         {{- if or (kindIs "bool" $value) (kindIs "float64" $value) (kindIs "int" $value) }}
         value: {{ $value }}
         {{- else }}
-        value: {{ $value | replace "$$" $sentinelDollarEscaped | replace "$" "$$" | replace $sentinelDollarEscaped "$$" | quote }}
+        value: {{ $value | replace "$$" $sentinelDollarEscaped | replace "$" "$$" | replace $sentinelDollarEscaped "$$" | replace "\\n" $sentinelNewlineEscaped | quote }}
         forceString: true
         {{- end }}
         {{- end -}}
@@ -116,7 +117,7 @@ steps:
         echo "📊 Parameters:"
         echo "------------------------------------------------------"
         # Extract only the parameters section onwards, skipping warnings
-        sed -n '/^parameters:/,$p' "$ARGO_PARAMETERS_RAW_FILE" > "${ARGO_PARAMETERS_FILE}"
+        sed -n '/^parameters:/,$p' "$ARGO_PARAMETERS_RAW_FILE" | sed 's/::NEWLINE_ESCAPED::/\\\\\\\\n/g' > "${ARGO_PARAMETERS_FILE}"
         cat "${ARGO_PARAMETERS_FILE}"
         echo "------------------------------------------------------"
 
@@ -179,24 +180,6 @@ steps:
         echo "------------------------------------------------------"
         cat $ARGO_APP_VALUE_FILE
         echo "------------------------------------------------------"
-
-  - annotation:
-      app-name: << parameters.release-name >>
-      namespace: << parameters.namespace >>
-      resource-name: rollout
-      set-name: "kubernetes.io/previous-tag"
-      get-current-name: kubernetes\.io\/current-tag
-      set-path-annotation: << parameters.set-path-annotation >>
-      get-current-value: true
-      ignore-not-found: true
-
-  - annotation:
-      app-name: << parameters.release-name >>
-      namespace: << parameters.namespace >>
-      resource-name: rollout
-      set-name: "kubernetes.io/current-tag"
-      set-value: "<< parameters.image-tag >>"
-      ignore-not-found: true
 
   - run:
       name: Upsert Argo Application

--- a/src/jobs/argo-deploy.yml
+++ b/src/jobs/argo-deploy.yml
@@ -85,13 +85,18 @@ parameters:
     type: string
     default: tiendanube
   # New parameters for ArgoCD migration workflow
-  migration-feedback-timeout:
+  argocd-migration-feedback-timeout:
     description: >
       The maximum time to wait for user feedback during the ArgoCD migration workflow (e.g. 1s, 2m, 3h).
       Must be a floating point number with an optional suffix: 's' for seconds (the default), 'm' for minutes, 'h' for hours or 'd' for days.
       A duration of 0 (the default) disables the associated timeout, in order to wait until the migration finishes.
     type: string
     default: '0'
+  argocd-migration-workflow-enabled:
+    description: >
+      Enable the ArgoCD migration workflow.
+    type: boolean
+    default: true
 
 steps:
   - run:
@@ -217,15 +222,18 @@ steps:
       profile-file-name: /tmp/environment-profile
       old-school-chart-file: /tmp/helm-detection/chart_name
 
-  - run:
-      name: Triggers the ArgoCD migration workflow
-      environment:
-        ROLLOUT_STATUS_TIMEOUT: << parameters.rollout-status-timeout >>
-        ROLLOUT_STATUS_COMMON_SCRIPT: << include(scripts/argo_rollout_status_common.sh) >>
-        ARGO_CLI_COMMON_SCRIPT: << include(scripts/argo_cli_common.sh) >>
-        FEEDBACK_TIMEOUT: << parameters.migration-feedback-timeout >>
-        FEEDBACK_ANNOTATION_KEY: migration.argocd.io/approval-next-phase
-        FEEDBACK_CHECK_INTERVAL: 10
-        ROLLOUT_STATUS_CHECK_INTERVAL: 10
-        PROFILE_FILE_NAME: /tmp/environment-profile
-      command: << include(scripts/argo_migration_workflow.sh) >>
+  - when:
+      condition: << parameters.argocd-migration-workflow-enabled >>
+      steps:
+        - run:
+            name: Triggers the ArgoCD migration workflow
+            environment:
+              ROLLOUT_STATUS_TIMEOUT: << parameters.rollout-status-timeout >>
+              ROLLOUT_STATUS_COMMON_SCRIPT: << include(scripts/argo_rollout_status_common.sh) >>
+              ARGO_CLI_COMMON_SCRIPT: << include(scripts/argo_cli_common.sh) >>
+              FEEDBACK_TIMEOUT: << parameters.argocd-migration-feedback-timeout >>
+              FEEDBACK_ANNOTATION_KEY: migration.argocd.io/approval-next-phase
+              FEEDBACK_CHECK_INTERVAL: 10
+              ROLLOUT_STATUS_CHECK_INTERVAL: 10
+              PROFILE_FILE_NAME: /tmp/environment-profile
+            command: << include(scripts/argo_migration_workflow.sh) >>


### PR DESCRIPTION
## Why? 🤔

We need this change because…

## What? :page_with_curl:

Please add a summary for this pull requests

## Additional Links 🔗

<!-- Add any relevant links here, eg. to other pull requests or Jira tickets.
NOTE: In case there aren't any, remove this section -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added parameters to control ArgoCD migration: argocd-migration-workflow-enabled (default true) and argocd-migration-feedback-timeout (default '0').
  - Renamed migration-feedback-timeout to argocd-migration-feedback-timeout.
  - Migration workflow now runs only when enabled, allowing opt-in execution.
- Bug Fixes
  - Fixed newline handling in templated values and parameters to preserve intended formatting.
- Refactor
  - Removed automatic rollout annotation updates (previous-tag and current-tag) during application upsert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->