### PR TITLE
[BAC-418] Update eks-orb to properly handle line breaks

### DIFF
--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -67,11 +67,12 @@ steps:
         cat \<< 'EOF' > $PARAMETERS_CHART_DIR/templates/parameters.yaml
         {{- define "formatValue" -}}
         {{- $sentinelDollarEscaped := "::DOLLAR_ESCAPED::" -}}
+        {{- $sentinelNewlineEscaped := "::NEWLINE_ESCAPED::" -}}
         {{- $value := . -}}
         {{- if or (kindIs "bool" $value) (kindIs "float64" $value) (kindIs "int" $value) }}
         value: {{ $value }}
         {{- else }}
-        value: {{ $value | replace "$$" $sentinelDollarEscaped | replace "$" "$$" | replace $sentinelDollarEscaped "$$" | quote }}
+        value: {{ $value | replace "$$" $sentinelDollarEscaped | replace "$" "$$" | replace $sentinelDollarEscaped "$$" | replace "\\n" $sentinelNewlineEscaped | quote }}
         forceString: true
         {{- end }}
         {{- end -}}
@@ -116,7 +117,7 @@ steps:
         echo "📊 Parameters:"
         echo "------------------------------------------------------"
         # Extract only the parameters section onwards, skipping warnings
-        sed -n '/^parameters:/,$p' "$ARGO_PARAMETERS_RAW_FILE" > "${ARGO_PARAMETERS_FILE}"
+        sed -n '/^parameters:/,$p' "$ARGO_PARAMETERS_RAW_FILE" | sed 's/::NEWLINE_ESCAPED::/\\\\\\\\n/g' > "${ARGO_PARAMETERS_FILE}"
         cat "${ARGO_PARAMETERS_FILE}"
         echo "------------------------------------------------------"
 


### PR DESCRIPTION
## Why? 🤔

We need this change because…

## What? :page_with_curl:

Please add a summary for this pull requests

## Additional Links 🔗

<!-- Add any relevant links here, eg. to other pull requests or Jira tickets.
NOTE: In case there aren't any, remove this section -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves escaped newline characters in parameter values when generating deployment configurations, ensuring valid YAML output.
  * Prevents processing failures caused by newline-containing parameters, improving reliability for multi-line and newline-escaped content.
  * Enhances stability of deployments that include complex parameter values, with no changes required to existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->