### PR TITLE
[BAC-434] Use fixed ArgoCD CLI version in CircleCI deployment step

### DIFF
--- a/src/jobs/argo-deploy.yml
+++ b/src/jobs/argo-deploy.yml
@@ -135,7 +135,7 @@ steps:
       name: Install ArgoCD CLI
       command: |
         cd /tmp
-        curl -LO https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+        curl -LO https://github.com/argoproj/argo-cd/releases/download/v3.0.16/argocd-linux-amd64
         chmod +x ./argocd-linux-amd64
         sudo mv ./argocd-linux-amd64 /usr/local/bin/argocd
         argocd version --client


### PR DESCRIPTION
## Why? 🤔

We need this change because…

## What? :page_with_curl:

Please add a summary for this pull requests

## Additional Links 🔗

<!-- Add any relevant links here, eg. to other pull requests or Jira tickets.
NOTE: In case there aren't any, remove this section -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment pipeline now uses a fixed ArgoCD CLI version (v3.0.16) instead of tracking the latest.
  * Standardizes CLI behavior across runs and environments, reducing unexpected variations during deploys.
  * No changes to application features or user interfaces.
  * Release processes remain unchanged for end users; functionality is unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->