### PR TITLE
[BAC-422] Check ArgoCD App status before rollout

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,7 +145,7 @@ workflows:
             --set-string labels.commit_id=${CIRCLE_SHA1:0:7} \
             --set-string labels.protected_branch="false" \
             --set-string labels.version=${CIRCLE_BRANCH} \
-            --set-string env.DUMMY_ENV_VAR="dummy-value-2" \
+            --set-string env.DUMMY_ENV_VAR="dummy-value-3" \
           requires: [staging-argo-deploy-approval]
           filters: *filter-staging
   staging-helmv3-test-and-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,6 +145,7 @@ workflows:
             --set-string labels.commit_id=${CIRCLE_SHA1:0:7} \
             --set-string labels.protected_branch="false" \
             --set-string labels.version=${CIRCLE_BRANCH} \
+            --set-string env.DUMMY_ENV_VAR="dummy-value" \
           requires: [staging-argo-deploy-approval]
           filters: *filter-staging
   staging-helmv3-test-and-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,7 +145,7 @@ workflows:
             --set-string labels.commit_id=${CIRCLE_SHA1:0:7} \
             --set-string labels.protected_branch="false" \
             --set-string labels.version=${CIRCLE_BRANCH} \
-            --set-string env.DUMMY_ENV_VAR="dummy-value" \
+            --set-string env.DUMMY_ENV_VAR="dummy-value-2" \
           requires: [staging-argo-deploy-approval]
           filters: *filter-staging
   staging-helmv3-test-and-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,7 +145,7 @@ workflows:
             --set-string labels.commit_id=${CIRCLE_SHA1:0:7} \
             --set-string labels.protected_branch="false" \
             --set-string labels.version=${CIRCLE_BRANCH} \
-            --set-string env.DUMMY_ENV_VAR="dummy-value-4" \
+            --set-string env.DUMMY_ENV_VAR="dummy-value-5" \
           requires: [staging-argo-deploy-approval]
           filters: *filter-staging
   staging-helmv3-test-and-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,7 +145,7 @@ workflows:
             --set-string labels.commit_id=${CIRCLE_SHA1:0:7} \
             --set-string labels.protected_branch="false" \
             --set-string labels.version=${CIRCLE_BRANCH} \
-            --set-string env.DUMMY_ENV_VAR="dummy-value-5" \
+            --set-string env.DUMMY_ENV_VAR="dummy-value-0" \
           requires: [staging-argo-deploy-approval]
           filters: *filter-staging
   staging-helmv3-test-and-deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -145,7 +145,7 @@ workflows:
             --set-string labels.commit_id=${CIRCLE_SHA1:0:7} \
             --set-string labels.protected_branch="false" \
             --set-string labels.version=${CIRCLE_BRANCH} \
-            --set-string env.DUMMY_ENV_VAR="dummy-value-3" \
+            --set-string env.DUMMY_ENV_VAR="dummy-value-4" \
           requires: [staging-argo-deploy-approval]
           filters: *filter-staging
   staging-helmv3-test-and-deploy:

--- a/src/commands/argo-app-previous-status.yml
+++ b/src/commands/argo-app-previous-status.yml
@@ -6,11 +6,11 @@ parameters:
   check-interval:
     description: Number of seconds to wait between status checks
     type: integer
-    default: 10
+    default: 15
   timeout:
     description: Maximum number of seconds to run status checks before quitting
     type: string
-    default: '1m'
+    default: '5m'
   debug:
     description: Whether to print debug information
     type: boolean
@@ -18,6 +18,7 @@ parameters:
 
 steps:
   - run:
+      name: Check ArgoCD Application status before new rollout
       environment:
         RELEASE_NAME: << parameters.release-name >>
         ARGO_APP_STATUS_TIMEOUT: << parameters.timeout >>

--- a/src/commands/argo-app-previous-status.yml
+++ b/src/commands/argo-app-previous-status.yml
@@ -6,11 +6,15 @@ parameters:
   check-interval:
     description: Number of seconds to wait between status checks
     type: integer
-    default: 15
+    default: 5
   timeout:
     description: Maximum number of seconds to run status checks before quitting
     type: string
     default: '5m'
+  sync_status_threshold:
+    description: Number of times that the result status is Sync before moving forward with the rollout
+    type: integer
+    default: 3
   debug:
     description: Whether to print debug information (use string to avoid boolean type conversion issues)
     type: string
@@ -23,6 +27,7 @@ steps:
         RELEASE_NAME: << parameters.release-name >>
         ARGO_APP_STATUS_TIMEOUT: << parameters.timeout >>
         ARGO_APP_STATUS_CHECK_INTERVAL: << parameters.check-interval >>
+        ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD: << parameters.sync_status_threshold >>
         ARGO_APP_STATUS_DEBUG: << parameters.debug >>
         ARGO_CLI_COMMON_SCRIPT: << include(scripts/argo_cli_common.sh) >>
       command: << include(scripts/argo_app_previous_status.sh) >>

--- a/src/commands/argo-app-previous-status.yml
+++ b/src/commands/argo-app-previous-status.yml
@@ -1,4 +1,4 @@
-description: Checks status of ArgoCD Application before new rollout is launched
+description: Check ArgoCD Application status before new rollout
 
 parameters:
   release-name:
@@ -14,11 +14,10 @@ parameters:
   debug:
     description: Whether to print debug information
     type: boolean
-    default: true
+    default: false
 
 steps:
   - run:
-      name: Check if ArgoCD Application is in valid state before new rollout
       environment:
         RELEASE_NAME: << parameters.release-name >>
         ARGO_APP_STATUS_TIMEOUT: << parameters.timeout >>

--- a/src/commands/argo-app-previous-status.yml
+++ b/src/commands/argo-app-previous-status.yml
@@ -14,7 +14,7 @@ parameters:
   debug:
     description: Whether to print debug information
     type: boolean
-    default: false
+    default: true
 
 steps:
   - run:

--- a/src/commands/argo-app-previous-status.yml
+++ b/src/commands/argo-app-previous-status.yml
@@ -12,9 +12,9 @@ parameters:
     type: string
     default: '5m'
   debug:
-    description: Whether to print debug information
-    type: boolean
-    default: false
+    description: Whether to print debug information (use string to avoid boolean type conversion issues)
+    type: string
+    default: "false"
 
 steps:
   - run:

--- a/src/commands/argo-app-previous-status.yml
+++ b/src/commands/argo-app-previous-status.yml
@@ -24,4 +24,5 @@ steps:
         ARGO_APP_STATUS_TIMEOUT: << parameters.timeout >>
         ARGO_APP_STATUS_CHECK_INTERVAL: << parameters.check-interval >>
         ARGO_APP_STATUS_DEBUG: << parameters.debug >>
+        ARGO_CLI_COMMON_SCRIPT: << include(scripts/argo_cli_common.sh) >>
       command: << include(scripts/argo_app_previous_status.sh) >>

--- a/src/commands/argo-app-previous-status.yml
+++ b/src/commands/argo-app-previous-status.yml
@@ -1,0 +1,27 @@
+description: Checks status of ArgoCD Application before new rollout is launched
+
+parameters:
+  release-name:
+    type: string
+  check-interval:
+    description: Number of seconds to wait between status checks
+    type: integer
+    default: 10
+  timeout:
+    description: Maximum number of seconds to run status checks before quitting
+    type: string
+    default: '1m'
+  debug:
+    description: Whether to print debug information
+    type: boolean
+    default: false
+
+steps:
+  - run:
+      name: Check if ArgoCD Application is in valid state before new rollout
+      environment:
+        RELEASE_NAME: << parameters.release-name >>
+        ARGO_APP_STATUS_TIMEOUT: << parameters.timeout >>
+        ARGO_APP_STATUS_CHECK_INTERVAL: << parameters.check-interval >>
+        ARGO_APP_STATUS_DEBUG: << parameters.debug >>
+      command: << include(scripts/argo_app_previous_status.sh) >>

--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -38,12 +38,6 @@ parameters:
   # Parameters for ArgoCD Application migration
 
 steps:
-  - when:
-      condition: << parameters.check-valid-previous-status >>
-      steps:
-        - argo-app-previous-status:
-            release-name: << parameters.release-name >>
-
   - run:
       name: Compute ArgoCD Application parameters from Helm chart
       command: |
@@ -201,6 +195,12 @@ steps:
         echo "------------------------------------------------------"
         cat $ARGO_APP_VALUE_FILE
         echo "------------------------------------------------------"
+
+  - when:
+      condition: << parameters.check-valid-previous-status >>
+      steps:
+        - argo-app-previous-status:
+            release-name: << parameters.release-name >>
 
   - run:
       name: Upsert Argo Application

--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -28,6 +28,9 @@ parameters:
     type: string
   rollout-status:
     type: boolean
+  check-valid-previous-status:
+    type: boolean
+    default: true
   # Parameters for ArgoCD Application migration
   old-school-chart-file:
     description: The file name of the chart used before migrating
@@ -35,6 +38,12 @@ parameters:
   # Parameters for ArgoCD Application migration
 
 steps:
+  - when:
+      condition: << parameters.check-valid-previous-status >>
+      steps:
+        - argo-app-previous-status:
+            release-name: << parameters.release-name >>
+
   - run:
       name: Compute ArgoCD Application parameters from Helm chart
       command: |

--- a/src/scripts/README.ArgoCD.md
+++ b/src/scripts/README.ArgoCD.md
@@ -30,9 +30,9 @@ The following conditions allow a rollout to continue or complete. These scenario
 ## status.sync.status
 The field `status.sync.status` in the _ArgoCD Application_ resource indicates the **synchronization** state between the desired configuration (as defined in _Git_) and the actual state of the resources in the cluster.
 Possible values:
-  - `Synced`: The live state matches the desired state in Git.
-  - `OutOfSync`: The live state differs from the desired state in Git (there are changes to apply).
-  - `Unknown`: The sync status could not be determined (e.g., due to errors or missing information).
+- `Synced`: The live state matches the desired state in Git.
+- `OutOfSync`: The live state differs from the desired state in Git (there are changes to apply).
+- `Unknown`: The sync status could not be determined (e.g., due to errors or missing information).
 
 ## status.health.status
 The field `status.health.status` in the _ArgoCD Application_ resource describes the **health** of the application as determined by _ArgoCD_. This field helps you understand whether the application and its resources are operating as expected.

--- a/src/scripts/README.ArgoCD.md
+++ b/src/scripts/README.ArgoCD.md
@@ -1,0 +1,55 @@
+# ArgoCD Rollout Decision Logic
+
+## 🚫 Rollout Blocked
+These conditions prevent a rollout from continuing and require manual intervention:
+
+- **⏸️ Canary Rollout in Progress**
+  - `health.status`: `Suspended` (regardless of sync status)
+  - _Reason_: A canary deployment is currently paused, waiting for manual approval or verification before proceeding to the next phase.
+
+- **⏳ Reconciliation Blocked**
+  - `operationState.phase`: `Running`
+  - _Reason_: The application is stuck in a reconciliation loop, indicating potential resource conflicts or configuration issues that need to be resolved before continuing.
+
+## ✅ Rollout Allowed
+The following conditions allow a rollout to continue or complete. These scenarios are not explicitly handled by any code; they are identified cases where the ORB will not cancel the rollout process.
+
+- **✅ Happy Path (Default Case):**  
+  - All statuses are healthy and in sync (`health.status`: `Healthy`, `sync.status`: `Synced`, `operationState.phase`: `Succeeded`).  
+  - _Reason_: Everything is operating as expected, so the rollout will proceed normally.
+
+- **↩️ Rollback Operation**
+  - `health.status`: `Healthy`, `sync.status`: `OutOfSync` (with _AutoSync_ **disabled** 🔒), and `operationState.phase`: `Succeeded`
+  - _Reason_: The application is healthy but intentionally out of sync due to a rollback operation that has completed successfully.
+
+- **🛑 Abort Operation**
+  - `health.status`: `Degraded`, `sync.status`: `Synced` (with _AutoSync_ **enabled** 🔄), and `operationState.phase`: `Succeeded`
+  - _Reason_: The application is in a degraded state but has successfully synced, indicating an abort operation that has completed and the system is ready for the next phase.
+
+# ArgoCD Application JSON fields reference
+## status.sync.status
+The field `status.sync.status` in the _ArgoCD Application_ resource indicates the **synchronization** state between the desired configuration (as defined in _Git_) and the actual state of the resources in the cluster.
+Possible values:
+  - `Synced`: The live state matches the desired state in Git.
+  - `OutOfSync`: The live state differs from the desired state in Git (there are changes to apply).
+  - `Unknown`: The sync status could not be determined (e.g., due to errors or missing information).
+
+## status.health.status
+The field `status.health.status` in the _ArgoCD Application_ resource describes the **health** of the application as determined by _ArgoCD_. This field helps you understand whether the application and its resources are operating as expected.
+
+Possible values:
+- `Healthy`: The application is operating normally and all resources are in the desired state.
+- `Progressing`: The application is being updated or is in the process of reconciling changes.
+- `Suspended`: The application rollout or sync is paused, often due to a manual intervention or a canary rollout step.
+- `Degraded`: One or more resources are in a failed or error state.
+- `Missing`: Some resources defined in the desired state are not found in the cluster.
+- `Unknown`: The health status could not be determined, possibly due to errors or missing information.
+
+## status.operationState.phase
+The field `status.operationState.phase` in the _ArgoCD Application_ resource represents the **current phase of the most recent operation** (such as a sync or rollback) performed on the application.
+
+Possible values:
+- `Running`: An operation (e.g., sync or rollback) is currently in progress. In the ArgoCD UI, this is often shown as "Syncing".
+- `Succeeded`: The last operation completed successfully. In the ArgoCD UI, this is often shown as "Sync OK".
+- `Failed`: The last operation did not complete successfully due to an error or issue with the resources.
+- `Error`: An unexpected error occurred during the operation.

--- a/src/scripts/argo_add_repository.sh
+++ b/src/scripts/argo_add_repository.sh
@@ -22,6 +22,7 @@ if [[ -z "${ARGO_CLI_COMMON_SCRIPT:-}" ]]; then
   exit 2
 fi
 
+#shellcheck disable=SC1090
 source <(echo "$ARGO_CLI_COMMON_SCRIPT")
 
 # Check that the with_argocd_cli function is available

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -43,7 +43,7 @@ function validate_requirements() {
 }
 
 function print_header() {
-  echo "========================================================"
+  echo "============================================================="
   echo "🔍 Checking Argo Application Health and Sync status for:"
   echo "   - Release: ${RELEASE_NAME}"
   echo "   - Namespace: ${APPLICATION_NAMESPACE}"
@@ -51,7 +51,7 @@ function print_header() {
   echo "   - Check interval: ${ARGO_APP_STATUS_CHECK_INTERVAL} (seconds)"
   echo "   - Sync status threshold: ${ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD}"
   echo "   - Debug: ${ARGO_APP_STATUS_DEBUG}"
-  echo "========================================================"
+  echo "============================================================="
 }
 
 # shellcheck disable=SC2329
@@ -71,7 +71,7 @@ function print_rollout_blocked_tip() {
   local operation_phase="$3"
 
   echo -e "${YELLOW}⚠️ ArgoCD Application Health: ${health_status}; Sync status: ${sync_status}; Operation Phase: ${operation_phase}; waiting...${NC}"
-  echo -e "========================================================"
+  echo -e -------------------------------------------------------------
   echo -e "${YELLOW}💡 Tip:${NC}"
   echo -e "${YELLOW}You can visit the ArgoCD UI to help resolve the conflict status if needed.${NC}"
   if [[ "$health_status" == "Suspended" ]]; then
@@ -80,7 +80,7 @@ function print_rollout_blocked_tip() {
     echo -e "${YELLOW}If the operation is blocked, evaluate using the 'Terminate' operation (at your own risk).${NC}"
   fi
   echo -e "${BLUE}🔗 Read the docs: ${ARGOCD_DOCS_URL}${NC}"
-  echo -e "========================================================"
+  echo -e -------------------------------------------------------------
 }
 
 #shellcheck disable=SC2329
@@ -90,7 +90,6 @@ function check_argocd_app_status() {
   local wait_for_multiple_healthy_status=false
 
   while true; do
-    echo "------------------------------------------------------"
     echo "🔍 Checking Argo Application status (attempt $i)..."
 
     output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app get "${RELEASE_NAME}" --output json)
@@ -134,7 +133,7 @@ function check_argocd_app_status() {
       fi
     fi
 
-    echo "------------------------------------------------------"
+    echo ""
     i=$((i+1))
     sleep "${ARGO_APP_STATUS_CHECK_INTERVAL}"
   done

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -44,14 +44,14 @@ function check_argocd_app_status() {
       echo "$output"
     fi
     if echo "$output" | grep "Sync Status:.*OutOfSync" >/dev/null 2>&1; then
-      echo -e "${YELLOW}ArgoCD Application is out of sync${NC}"
+      echo -e "${YELLOW}⚠️ ArgoCD Application is out of sync${NC}"
       if echo "$output" | grep "Health Status:.*Suspended" >/dev/null 2>&1; then
-        echo -e "${YELLOW}ArgoCD Application is suspended${NC}"
+        echo -e "${YELLOW}⚠️ ArgoCD Application is suspended${NC}"
       elif echo "$output" | grep "Health Status:.*Progressing" >/dev/null 2>&1; then
-        echo -e "${YELLOW}ArgoCD Application is progressing${NC}"
+        echo -e "${YELLOW}⚠️ ArgoCD Application is progressing${NC}"
       fi
     else
-      echo -e "${GREEN}ArgoCD Application is in valid state for deployment${NC}"
+      echo -e "${GREEN}✅ ArgoCD Application is in valid state for deployment${NC}"
       echo "$output"
       exit 0
     fi
@@ -64,7 +64,7 @@ set +e
 
 if [[ -z "$RELEASE_NAME" ]] || [[ -z "$ARGO_APP_STATUS_TIMEOUT" ]] || 
    [[ -z "$ARGO_APP_STATUS_CHECK_INTERVAL" ]] || [[ -z "$ARGO_CLI_COMMON_SCRIPT" ]]; then
-  echo -e "${RED}Error: RELEASE_NAME, ARGO_APP_STATUS_TIMEOUT, ARGO_APP_STATUS_CHECK_INTERVAL, and ARGO_CLI_COMMON_SCRIPT are required.${NC}"
+  echo -e "${RED}❌ Error: RELEASE_NAME, ARGO_APP_STATUS_TIMEOUT, ARGO_APP_STATUS_CHECK_INTERVAL, and ARGO_CLI_COMMON_SCRIPT are required.${NC}"
   exit 2
 fi
 
@@ -74,10 +74,11 @@ fi
 
 # Validate that argocd CLI is available
 if ! command -v argocd >/dev/null 2>&1; then
-  echo -e "${RED}Error: argocd CLI is not installed or not in PATH.${NC}"
+  echo -e "${RED}❌ Error: argocd CLI is not installed or not in PATH.${NC}"
   exit 2
 fi
 
+#shellcheck disable=SC1090
 source <(echo "$ARGO_CLI_COMMON_SCRIPT")
 
 # Check that the with_argocd_cli function is available
@@ -94,6 +95,7 @@ export RELEASE_NAME ARGO_APP_STATUS_CHECK_INTERVAL ARGO_APP_STATUS_DEBUG
 
 timeout "${ARGO_APP_STATUS_TIMEOUT}" bash -o pipefail -c "$(cat <<EOF
   $(declare -f check_argocd_app_status)
+  $(declare -f with_argocd_cli)
   check_argocd_app_status
 EOF
 )" || TIMEOUT_RESULT=$?

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -80,24 +80,23 @@ if ! command -v argocd >/dev/null 2>&1; then
   exit 2
 fi
 
-#shellcheck disable=SC1090
-source <(echo "$ARGO_CLI_COMMON_SCRIPT")
-
-# Check that the with_argocd_cli function is available
-if ! declare -f with_argocd_cli > /dev/null; then
-  echo -e "${RED}❌ with_argocd_cli function is not defined in subshell!${NC}"
-  exit 2
-fi
-
 print_header
 
 TIMEOUT_RESULT=0
 
-export RELEASE_NAME ARGO_APP_STATUS_CHECK_INTERVAL ARGO_APP_STATUS_DEBUG
+export RELEASE_NAME ARGO_APP_STATUS_CHECK_INTERVAL ARGO_APP_STATUS_DEBUG ARGO_CLI_COMMON_SCRIPT
 
 timeout "${ARGO_APP_STATUS_TIMEOUT}" bash -o pipefail -c "$(cat <<EOF
   $(declare -f check_argocd_app_status)
-  $(declare -f with_argocd_cli)
+  
+  source <(echo "$ARGO_CLI_COMMON_SCRIPT")
+
+  # Check that the with_argocd_cli function is available
+  if ! declare -f with_argocd_cli > /dev/null; then
+    echo -e "${RED}❌ with_argocd_cli function is not defined in subshell!${NC}"
+    exit 2
+  fi
+
   check_argocd_app_status
 EOF
 )" || TIMEOUT_RESULT=$?

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -29,8 +29,10 @@ function print_header() {
   echo "========================================================"
   echo "🔍 Checking Argo Application Health and Sync status for:"
   echo "   - Release: ${RELEASE_NAME}"
+  echo "   - Namespace: ${APPLICATION_NAMESPACE}"
   echo "   - Timeout: ${ARGO_APP_STATUS_TIMEOUT}"
-  echo "   - Check interval: ${ARGO_APP_STATUS_CHECK_INTERVAL}s"
+  echo "   - Check interval: ${ARGO_APP_STATUS_CHECK_INTERVAL} (seconds)"
+  echo "   - Sync status threshold: ${ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD}"
   echo "   - Debug: ${ARGO_APP_STATUS_DEBUG}"
   echo "========================================================"
 }
@@ -120,6 +122,11 @@ if [[ -z "$RELEASE_NAME" ]] || [[ -z "$ARGO_APP_STATUS_TIMEOUT" ]] ||
   exit 2
 fi
 
+if ! [[ "$ARGO_APP_STATUS_CHECK_INTERVAL" =~ ^[0-9]+$ && "$ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD" =~ ^[0-9]+$ ]]; then
+  echo -e "${RED}❌ Error: CHECK_INTERVAL and SYNC_STATUS_THRESHOLD must be integers (seconds/count).${NC}"
+  exit 2
+fi
+
 if [[ -z "$ARGO_APP_STATUS_DEBUG" ]]; then
   ARGO_APP_STATUS_DEBUG=false
 fi
@@ -151,7 +158,8 @@ TIMEOUT_RESULT=0
 
 export GREEN BLUE YELLOW RED NC
 export ARGOCD_DOCS_URL
-export RELEASE_NAME ARGO_APP_STATUS_CHECK_INTERVAL ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD ARGO_APP_STATUS_DEBUG ARGO_CLI_COMMON_SCRIPT
+export RELEASE_NAME APPLICATION_NAMESPACE
+export ARGO_APP_STATUS_CHECK_INTERVAL ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD ARGO_APP_STATUS_DEBUG ARGO_CLI_COMMON_SCRIPT
 
 timeout "${ARGO_APP_STATUS_TIMEOUT}" bash -o pipefail -c "$(cat <<EOF
   $(declare -f check_argocd_app_status print_rollout_blocked_tip print_debug_output with_argocd_cli set_argocd_cli unset_argocd_cli)

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -39,9 +39,11 @@ function check_argocd_app_status() {
   while true; do
     echo "========================================================"
     echo "🔍 Checking Argo Application status (attempt $i)..."
-    output=$(with_argocd_cli -- argocd app get "argocd/${RELEASE_NAME}")
+    output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app get "${RELEASE_NAME}")
     if [[ $ARGO_APP_STATUS_DEBUG == true ]]; then
+      echo "-----CMD OUTPUT---------------------------------------------"
       echo "$output"
+      echo "------------------------------------------------------------"
     fi
     if echo "$output" | grep "Sync Status:.*OutOfSync" >/dev/null 2>&1; then
       echo -e "${YELLOW}⚠️ ArgoCD Application is out of sync${NC}"

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -47,8 +47,11 @@ function check_argocd_app_status() {
       echo "------------------------------------------------------------"
     fi
 
-    sync_status=$(echo "$output" | jq -r '.status.sync.status // "Unknown"')
-    health_status=$(echo "$output" | jq -r '.status.health.status // "Unknown"')
+    # Extract JSON part by finding the first '{' and taking everything from there
+    json_output=$(echo "$output" | sed -n '/^{/,$p')
+    
+    sync_status=$(echo "$json_output" | jq -r '.status.sync.status // "Unknown"')
+    health_status=$(echo "$json_output" | jq -r '.status.health.status // "Unknown"')
     if [[ "$sync_status" == "OutOfSync" ]]; then
       echo -e "${YELLOW}⚠️ ArgoCD Application is OutOfSync with health status: ${health_status}${NC}"
     else

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -28,7 +28,7 @@ function print_header() {
   echo "   - Timeout: ${ARGO_APP_STATUS_TIMEOUT}"
   echo "   - Check interval: ${ARGO_APP_STATUS_CHECK_INTERVAL}s"
   echo "   - Debug: ${ARGO_APP_STATUS_DEBUG}"
-  echo "--------------------------------------------------------"
+  echo "========================================================"
 }
 
 #shellcheck disable=SC2329
@@ -40,7 +40,7 @@ function check_argocd_app_status() {
     echo "========================================================"
     echo "🔍 Checking Argo Application status (attempt $i)..."
 
-    output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app get "${RELEASE_NAME}" -o json)
+    output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app get "${RELEASE_NAME}" --output json)
     if [[ $ARGO_APP_STATUS_DEBUG == true ]]; then
       echo "---- CMD OUTPUT --------------------------------------------"
       echo "$output"

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -70,7 +70,7 @@ function check_argocd_app_status() {
       echo -e "${GREEN}✅ ArgoCD Application is 'Synced'; health: ${health_status}${NC}"
       if [[ "$sync_status_count" -ge "$ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD" ]]; then
         echo "$json_output"
-        echo -e "${GREEN}After ${sync_status_count} successful attempts, DONE.${NC}"
+        echo -e "${GREEN}✅After ${sync_status_count} successful attempts, DONE.${NC}"
         exit 0
       else
         echo -e "${GREEN}Waiting for consecutive 'Synced' status...${NC}"
@@ -123,6 +123,7 @@ print_header
 
 TIMEOUT_RESULT=0
 
+export GREEN RED YELLOW NC
 export RELEASE_NAME ARGO_APP_STATUS_CHECK_INTERVAL ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD ARGO_APP_STATUS_DEBUG ARGO_CLI_COMMON_SCRIPT
 
 timeout "${ARGO_APP_STATUS_TIMEOUT}" bash -o pipefail -c "$(cat <<EOF

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -41,7 +41,7 @@ function check_argocd_app_status() {
     echo "🔍 Checking Argo Application status (attempt $i)..."
 
     output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app get "${RELEASE_NAME}" --output json)
-    if [[ $ARGO_APP_STATUS_DEBUG ]]; then
+    if [[ $ARGO_APP_STATUS_DEBUG == "true" ]]; then
       echo "---- CMD OUTPUT --------------------------------------------"
       echo "$output"
       echo "------------------------------------------------------------"

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -12,8 +12,8 @@
 #   ARGO_CLI_COMMON_SCRIPT                 - The script to source for required functions
 #
 # Returns:
-#   - Exit code 0 if application Sync Status is Synced (regardless of Health).
-#   - Exit code 1 if application remains OutOfSync until timeout.
+#   - Exit code 0 if application Rollout can proceed: Health or Degraded, Sync or OutOfSync.
+#   - Exit code 1 if application Rollout should be blocked: remains Suspended or Syncing until timeout.
 #   - Exit code 2 for script errors
 
 # Colors for output

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -41,7 +41,7 @@ function check_argocd_app_status() {
     echo "🔍 Checking Argo Application status (attempt $i)..."
 
     output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app get "${RELEASE_NAME}" --output json)
-    if [[ $ARGO_APP_STATUS_DEBUG == true ]]; then
+    if [[ $ARGO_APP_STATUS_DEBUG ]]; then
       echo "---- CMD OUTPUT --------------------------------------------"
       echo "$output"
       echo "------------------------------------------------------------"

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -71,7 +71,7 @@ function print_rollout_blocked_tip() {
   local operation_phase="$3"
 
   echo -e "${YELLOW}⚠️ ArgoCD Application Health: ${health_status}; Sync status: ${sync_status}; Operation Phase: ${operation_phase}; waiting...${NC}"
-  echo -e "************************************************************************************"
+  echo -e "========================================================"
   echo -e "${YELLOW}💡 Tip:${NC}"
   echo -e "${YELLOW}You can visit the ArgoCD UI to help resolve the conflict status if needed.${NC}"
   if [[ "$health_status" == "Suspended" ]]; then
@@ -79,8 +79,8 @@ function print_rollout_blocked_tip() {
   else
     echo -e "${YELLOW}If the operation is blocked, evaluate using the 'Terminate' operation (at your own risk).${NC}"
   fi
-  echo -e "${BLUE}🔗 Using ArgoCD for Progressive Delivery: ${ARGOCD_DOCS_URL}${NC}"
-  echo -e "************************************************************************************"
+  echo -e "${BLUE}🔗 Read the docs: ${ARGOCD_DOCS_URL}${NC}"
+  echo -e "========================================================"
 }
 
 #shellcheck disable=SC2329
@@ -90,7 +90,7 @@ function check_argocd_app_status() {
   local wait_for_multiple_healthy_status=false
 
   while true; do
-    echo "========================================================"
+    echo "------------------------------------------------------"
     echo "🔍 Checking Argo Application status (attempt $i)..."
 
     output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app get "${RELEASE_NAME}" --output json)
@@ -134,7 +134,7 @@ function check_argocd_app_status() {
       fi
     fi
 
-    echo "========================================================"
+    echo "------------------------------------------------------"
     i=$((i+1))
     sleep "${ARGO_APP_STATUS_CHECK_INTERVAL}"
   done

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -80,6 +80,15 @@ if ! command -v argocd >/dev/null 2>&1; then
   exit 2
 fi
 
+#shellcheck disable=SC1090
+source <(echo "$ARGO_CLI_COMMON_SCRIPT")
+
+# Check that the with_argocd_cli function is available
+if ! declare -f with_argocd_cli > /dev/null; then
+  echo -e "${RED}❌ with_argocd_cli function is not defined in subshell!${NC}"
+  exit 2
+fi
+
 print_header
 
 TIMEOUT_RESULT=0
@@ -87,16 +96,7 @@ TIMEOUT_RESULT=0
 export RELEASE_NAME ARGO_APP_STATUS_CHECK_INTERVAL ARGO_APP_STATUS_DEBUG ARGO_CLI_COMMON_SCRIPT
 
 timeout "${ARGO_APP_STATUS_TIMEOUT}" bash -o pipefail -c "$(cat <<EOF
-  $(declare -f check_argocd_app_status)
-  
-  source <(echo "$ARGO_CLI_COMMON_SCRIPT")
-
-  # Check that the with_argocd_cli function is available
-  if ! declare -f with_argocd_cli > /dev/null; then
-    echo -e "${RED}❌ with_argocd_cli function is not defined in subshell!${NC}"
-    exit 2
-  fi
-
+  $(declare -f check_argocd_app_status with_argocd_cli set_argocd_cli unset_argocd_cli)
   check_argocd_app_status
 EOF
 )" || TIMEOUT_RESULT=$?

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Script to check the status of an Argo Application
+#
+# Usage: Set the following environment variables:
+#   RELEASE_NAME                   - The release name to check
+#   ARGO_APP_STATUS_TIMEOUT        - Timeout in seconds
+#   ARGO_APP_STATUS_CHECK_INTERVAL - Interval between checks in seconds
+#   ARGO_APP_STATUS_DEBUG          - Whether to print debug information
+#
+# Returns:
+#   - Exit code 0 if application is Synced (in any state: Healthy, Completed, Degraded, Error, or Aborted).
+#   - Exit code 1 if application is OutOfSync (Suspended or Progressing) and timeout is reached.
+#   - Exit code 2 for script errors
+
+# Print status header
+function print_header() {
+  echo "========================================================"
+  echo "🔍 Checking Argo Application Health and Sync status for:"
+  echo "   - Release: ${RELEASE_NAME}"
+  echo "   - Timeout: ${ARGO_APP_STATUS_TIMEOUT}"
+  echo "   - Check interval: ${ARGO_APP_STATUS_CHECK_INTERVAL}s"
+  echo "   - Debug: ${ARGO_APP_STATUS_DEBUG}"
+  echo "--------------------------------------------------------"
+}
+
+#shellcheck disable=SC2329
+function check_argocd_app_status() {
+  local output
+  local i=1
+
+  while true; do
+    echo "========================================================"
+    echo "🔍 Checking Argo Application status (attempt $i)..."
+    output=$(argocd app get "argocd/${RELEASE_NAME}")
+    if [[ $ARGO_APP_STATUS_DEBUG == true ]]; then
+      echo "$output"
+    fi
+    if echo "$output" | grep "Sync Status:.*OutOfSync" >/dev/null 2>&1; then
+      echo "ArgoCD Application is out of sync"
+      if echo "$output" | grep "Health Status:.*Suspended" >/dev/null 2>&1; then
+        echo "ArgoCD Application is suspended"
+      elif echo "$output" | grep "Health Status:.*Progressing" >/dev/null 2>&1; then
+        echo "ArgoCD Application is progressing"
+      fi
+    else
+      echo "ArgoCD Application is in valid state for deployment"
+      echo "$output"
+      exit 0
+    fi
+    i=$((i+1))
+    sleep "${ARGO_APP_STATUS_CHECK_INTERVAL}"
+  done
+}
+
+set +e
+
+if [[ -z "$RELEASE_NAME" ]] || [[ -z "$ARGO_APP_STATUS_TIMEOUT" ]] || [[ -z "$ARGO_APP_STATUS_CHECK_INTERVAL" ]]; then
+  echo "Error: RELEASE_NAME, ARGO_APP_STATUS_TIMEOUT, and ARGO_APP_STATUS_CHECK_INTERVAL are required."
+  exit 2
+fi
+
+if [[ -z "$ARGO_APP_STATUS_DEBUG" ]]; then
+  ARGO_APP_STATUS_DEBUG=false
+fi
+
+print_header
+
+TIMEOUT_RESULT=0
+
+export RELEASE_NAME ARGO_APP_STATUS_CHECK_INTERVAL ARGO_APP_STATUS_DEBUG
+
+timeout "${ARGO_APP_STATUS_TIMEOUT}" bash -o pipefail -c "$(cat <<EOF
+  $(declare -f check_argocd_app_status)
+  check_argocd_app_status
+EOF
+)" || TIMEOUT_RESULT=$?
+
+if [[ $TIMEOUT_RESULT -eq 124 ]]; then
+  echo "⏰ Timeout reached while checking application status."
+  exit 1
+else
+  exit $TIMEOUT_RESULT
+fi

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -54,6 +54,15 @@ function check_argocd_app_status() {
     health_status=$(echo "$json_output" | jq -r '.status.health.status // "Unknown"')
     if [[ "$sync_status" == "OutOfSync" ]]; then
       echo -e "${YELLOW}⚠️ ArgoCD Application is OutOfSync; health: ${health_status}; waiting...${NC}"
+      echo -e "********************************************************"
+      echo -e "${YELLOW}💡 Tip:${NC}"
+      echo -e "${YELLOW}You can visit the ArgoCD UI to help resolve the OutOfSync status if needed.${NC}"
+      if [[ "$health_status" == "Suspended" ]]; then
+        echo -e "${YELLOW}Use the 'Abort', 'Resume' or 'Promote-Full' operations to unlock Suspended status.${NC}"
+      else
+        echo -e "${YELLOW}If the operation is blocked, use the 'Terminate' operation.${NC}"
+      fi
+      echo -e "********************************************************"
     elif [[ "$sync_status" == "Synced" ]]; then
       echo -e "${GREEN}✅ ArgoCD Application is Synced; health: ${health_status}${NC}"
       echo "$json_output"
@@ -62,6 +71,7 @@ function check_argocd_app_status() {
       echo -e "${YELLOW}⚠️ ArgoCD Application sync status is '${sync_status}'; waiting...${NC}"
     fi
 
+    echo "========================================================"
     i=$((i+1))
     sleep "${ARGO_APP_STATUS_CHECK_INTERVAL}"
   done

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -47,8 +47,8 @@ function check_argocd_app_status() {
       echo "------------------------------------------------------------"
     fi
 
-    # Extract JSON part by finding the first '{' and taking everything from there
-    json_output=$(echo "$output" | sed -n '/^{/,$p')
+    # Extract JSON part by finding the first '{' and last '}' to get only valid JSON
+    json_output=$(echo "$output" | awk '/^{/ {flag=1} flag && /^}$/ {print; exit} flag')
     
     sync_status=$(echo "$json_output" | jq -r '.status.sync.status // "Unknown"')
     health_status=$(echo "$json_output" | jq -r '.status.health.status // "Unknown"')

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -12,7 +12,7 @@
 #   ARGO_CLI_COMMON_SCRIPT                 - The script to source for required functions
 #
 # Returns:
-#   - Exit code 0 if application Rollout can proceed: Health or Degraded, Sync or OutOfSync.
+#   - Exit code 0 if application Rollout can proceed: Health or Degraded; Sync or OutOfSync.
 #   - Exit code 1 if application Rollout should be blocked: remains Suspended or Syncing until timeout.
 #   - Exit code 2 for script errors
 
@@ -24,6 +24,23 @@ RED="\033[0;31m"
 NC="\033[0m" # No Color
 
 ARGOCD_DOCS_URL="https://tiendanube.atlassian.net/wiki/spaces/EP/pages/494403591/Using+ArgoCD+for+Progressive+Delivery"
+
+function validate_requirements() {
+  if ! command -v argocd >/dev/null 2>&1; then
+    echo -e "${RED}❌ Error: argocd CLI is not installed or not in PATH.${NC}"
+    exit 2
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo -e "${RED}❌ Error: jq is not installed or not in PATH.${NC}"
+    exit 2
+  fi
+
+  if ! command -v timeout >/dev/null 2>&1; then
+    echo -e "${RED}❌ Error: timeout is not installed or not in PATH.${NC}"
+    exit 2
+  fi
+}
 
 function print_header() {
   echo "========================================================"
@@ -114,6 +131,10 @@ function check_argocd_app_status() {
   done
 }
 
+################################################################################
+# MAIN SCRIPT
+################################################################################
+
 set +e
 
 if [[ -z "$RELEASE_NAME" ]] || [[ -z "$ARGO_APP_STATUS_TIMEOUT" ]] || 
@@ -131,17 +152,7 @@ if [[ -z "$ARGO_APP_STATUS_DEBUG" ]]; then
   ARGO_APP_STATUS_DEBUG=false
 fi
 
-# Validate that ArgoCD CLI is available
-if ! command -v argocd >/dev/null 2>&1; then
-  echo -e "${RED}❌ Error: argocd CLI is not installed or not in PATH.${NC}"
-  exit 2
-fi
-
-# Validate that jq is available
-if ! command -v jq >/dev/null 2>&1; then
-  echo -e "${RED}❌ Error: jq is not installed or not in PATH.${NC}"
-  exit 2
-fi
+validate_requirements
 
 #shellcheck disable=SC1090
 source <(echo "$ARGO_CLI_COMMON_SCRIPT")

--- a/src/scripts/argo_cli_common.sh
+++ b/src/scripts/argo_cli_common.sh
@@ -87,5 +87,5 @@ function with_argocd_cli() {
   fi
 
   # FIXME: Allow some time for the change to propagate.
-  sleep 15
+  sleep 5
 }

--- a/src/scripts/argo_rollout_status_common.sh
+++ b/src/scripts/argo_rollout_status_common.sh
@@ -40,6 +40,7 @@ function exec_rollout_status() {
   fi
 
   # Print result
+  #shellcheck disable=SC2329
   function print_rollout_status_result() {
     local status="$1"
     local message="$2"
@@ -53,6 +54,7 @@ function exec_rollout_status() {
   }
 
   # Main status check loop
+  #shellcheck disable=SC2329
   function check_rollout_status() {
     local i=1
     while true; do


### PR DESCRIPTION
## Why? 🤔

We need to validate status of previous rollouts are OK and prevent launching a new rollout if another, a previous one, is in progress.

## Add ArgoCD application status check before rollout :page_with_curl:

- Introduced a new command to check the status of an ArgoCD application before launching a new rollout.
- Added parameters for release name, check interval, timeout, and debug options.
- Implemented a script to verify if the application is in a valid state, handling various sync and health statuses.
- Updated the deployment command to conditionally execute the status check based on a new parameter.
- Introduced a new README file detailing the conditions for rollout blocking and allowing in ArgoCD.

## Additional Links 🔗

[BAC-422](https://tiendanube.atlassian.net/browse/BAC-422)


[BAC-422]: https://tiendanube.atlassian.net/browse/BAC-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional pre-rollout ArgoCD application status check (enabled by default) as a gating step; configurable release, interval, timeout, consecutive-sync threshold, and debug mode; adds a resilient, observable watcher with timeout/retry and colorized logs.

- **Documentation**
  - Added ArgoCD rollout decision logic and field reference docs.

- **Chores**
  - Suppressed shell linter warnings, injected a staging Helm env value for CI, and reduced CLI retry sleep from 15s to 5s.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->