### PR TITLE
[BAC-435] Fix ArgoCD parameters wrong type: expected string got int64

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -120,6 +120,7 @@ workflows:
           values-file: .circleci/resources/values-test-rollout-staging.yml
           mesh: true
           args: |
+            --set env.LARGE_NUMBER_INT64=9123456789 \
             --set env.DB_HOST_PRIMARY=$(echo "$secret_string" | jq -r ".DB_HOST_PRIMARY") \
             --set env.SETTINGS_ENV=feature \
             --set env.SPRING_PROFILES_ACTIVE=feature \

--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -68,7 +68,9 @@ steps:
         {{- $sentinelDollarEscaped := "::DOLLAR_ESCAPED::" -}}
         {{- $sentinelNewlineEscaped := "::NEWLINE_ESCAPED::" -}}
         {{- $value := . -}}
-        {{- if or (kindIs "bool" $value) (kindIs "float64" $value) (kindIs "int" $value) }}
+        {{- if or (kindIs "bool" $value) 
+                  (kindIs "float" $value) (kindIs "float8" $value) (kindIs "float16" $value) (kindIs "float32" $value) (kindIs "float64" $value)
+                  (kindIs "int" $value) (kindIs "int8" $value) (kindIs "int16" $value) (kindIs "int32" $value) (kindIs "int64" $value) }}
         value: {{ $value }}
         {{- else }}
         value: {{ $value | replace "$$" $sentinelDollarEscaped | replace "$" "$$" | replace $sentinelDollarEscaped "$$" | replace "\\n" $sentinelNewlineEscaped | quote }}

--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -68,9 +68,7 @@ steps:
         {{- $sentinelDollarEscaped := "::DOLLAR_ESCAPED::" -}}
         {{- $sentinelNewlineEscaped := "::NEWLINE_ESCAPED::" -}}
         {{- $value := . -}}
-        {{- if or (kindIs "bool" $value) 
-                  (kindIs "float" $value) (kindIs "float8" $value) (kindIs "float16" $value) (kindIs "float32" $value) (kindIs "float64" $value)
-                  (kindIs "int" $value) (kindIs "int8" $value) (kindIs "int16" $value) (kindIs "int32" $value) (kindIs "int64" $value) }}
+        {{- if or (kindIs "bool" $value) (or (hasPrefix "int" (kindOf $value)) (hasPrefix "float" (kindOf $value))) }}
         value: {{ $value }}
         {{- else }}
         value: {{ $value | replace "$$" $sentinelDollarEscaped | replace "$" "$$" | replace $sentinelDollarEscaped "$$" | replace "\\n" $sentinelNewlineEscaped | quote }}


### PR DESCRIPTION
## What? Support every numeric type :page_with_curl:

Enhance value type checks in ArgoCD deployment configuration to support all kind of numeric types: int and float, from 8 to 64 bits.

[Valid Helm data types](https://helm.sh/docs/chart_template_guide/data_types/)

## Additional Links 🔗

[BAC-435](https://tiendanube.atlassian.net/browse/BAC-435)

