### PR TITLE
BAC-446 - Handle missing deploy in pre-deployment validation

### DIFF
--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -161,11 +161,17 @@ if [[ -z "$ARGO_APP_STATUS_DEBUG" ]]; then
 fi
 
 function validate_app_exists() {
-  local output
+  local output status
   output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app get "${RELEASE_NAME}" --output json 2>&1)
+  status=$?
   if echo "$output" | grep -q "PermissionDenied"; then
     echo -e "${YELLOW}ℹ️ Info: Cannot query ArgoCD Application '${RELEASE_NAME}' (does not exist). First deploy.${NC}"
     exit 0
+  fi
+  if [[ $status -ne 0 ]]; then
+    echo -e "${RED}❌ Error: Unexpected failure querying ArgoCD Application '${RELEASE_NAME}'.${NC}"
+    echo -e "${BLUE}Output:${NC} ${output}"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
## Why? 🤔

We need this change because…

## What? :page_with_curl:

Please add a summary for this pull requests

## Additional Links 🔗

<!-- Add any relevant links here, eg. to other pull requests or Jira tickets.
NOTE: In case there aren't any, remove this section -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an early pre-check that verifies whether the ArgoCD Application can be queried; if access is missing or the app doesn’t exist, the script exits gracefully with an informative message to avoid unnecessary waiting.
- Bug Fixes
  - Improved validation messages to reference ARGO_APP_STATUS_CHECK_INTERVAL and ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD.
- Other
  - Initialization now ensures required environment variables and helpers are available; rollout/wait behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->