### PR TITLE
[BAC-446] Handle missing deploy in pre-deployment validation

### DIFF
--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -84,7 +84,7 @@ function validate_app_exists() {
   fi
 
   # Extract JSON part by finding the first '[' or '{' and last ']' or '}' to get only valid JSON
-  json_output=$(echo "$output" | awk '/^[\[\{]/ {flag=1} flag && /^[\]\}]$/ {print; exit} flag')
+  json_output=$(echo "$output" | sed -n 's/.*\([\[\{].*[\]\}]\).*/\1/p' | head -1)
   
   # Use jq to analyze the output is valid JSON
   if ! echo "$json_output" | jq empty 2>/dev/null; then

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -25,6 +25,19 @@ NC="\033[0m" # No Color
 
 ARGOCD_DOCS_URL="https://tiendanube.atlassian.net/wiki/spaces/EP/pages/494403591/Using+ArgoCD+for+Progressive+Delivery"
 
+function validate_env_variables() {
+  if [[ -z "$RELEASE_NAME" ]] || [[ -z "$ARGO_APP_STATUS_TIMEOUT" ]] || 
+     [[ -z "$ARGO_APP_STATUS_CHECK_INTERVAL" ]] || [[ -z "$ARGO_CLI_COMMON_SCRIPT" ]]; then
+    echo -e "${RED}❌ Error: RELEASE_NAME, ARGO_APP_STATUS_TIMEOUT, ARGO_APP_STATUS_CHECK_INTERVAL, and ARGO_CLI_COMMON_SCRIPT are required.${NC}"
+    exit 2
+  fi
+
+  if ! [[ "$ARGO_APP_STATUS_CHECK_INTERVAL" =~ ^[0-9]+$ && "$ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD" =~ ^[0-9]+$ ]]; then
+    echo -e "${RED}❌ Error: ARGO_APP_STATUS_CHECK_INTERVAL and ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD must be integers (seconds/count).${NC}"
+    exit 2
+  fi
+}
+
 function validate_requirements() {
   if ! command -v argocd >/dev/null 2>&1; then
     echo -e "${RED}❌ Error: argocd CLI is not installed or not in PATH.${NC}"
@@ -145,16 +158,7 @@ function check_argocd_app_status() {
 
 set +e
 
-if [[ -z "$RELEASE_NAME" ]] || [[ -z "$ARGO_APP_STATUS_TIMEOUT" ]] || 
-   [[ -z "$ARGO_APP_STATUS_CHECK_INTERVAL" ]] || [[ -z "$ARGO_CLI_COMMON_SCRIPT" ]]; then
-  echo -e "${RED}❌ Error: RELEASE_NAME, ARGO_APP_STATUS_TIMEOUT, ARGO_APP_STATUS_CHECK_INTERVAL, and ARGO_CLI_COMMON_SCRIPT are required.${NC}"
-  exit 2
-fi
-
-if ! [[ "$ARGO_APP_STATUS_CHECK_INTERVAL" =~ ^[0-9]+$ && "$ARGO_APP_STATUS_SYNC_STATUS_THRESHOLD" =~ ^[0-9]+$ ]]; then
-  echo -e "${RED}❌ Error: CHECK_INTERVAL and SYNC_STATUS_THRESHOLD must be integers (seconds/count).${NC}"
-  exit 2
-fi
+validate_env_variables
 
 if [[ -z "$ARGO_APP_STATUS_DEBUG" ]]; then
   ARGO_APP_STATUS_DEBUG=false

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -69,12 +69,13 @@ function print_header() {
 
 function validate_app_exists() {
   local output status
+
   output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app list -l "app=${RELEASE_NAME}" --output json)
   status=$?
 
   if [[ $status -ne 0 ]]; then
     echo -e "${RED}❌ Error: Unexpected failure querying ArgoCD Application '${RELEASE_NAME}'.${NC}"
-    echo -e "${BLUE}Output:${NC} ${output}"
+    echo -e "${BLUE}📓 Output:${NC}\n${output}"
     exit 1
   fi
   
@@ -86,11 +87,13 @@ function validate_app_exists() {
   # Use jq to analyze the output is valid JSON
   if ! echo "$output" | jq empty 2>/dev/null; then
     echo -e "${RED}❌ Error: argocd app list command returned invalid JSON output.${NC}"
-    echo -e "${BLUE}Output:${NC} ${output}"
+    echo -e "${BLUE}📓 Output:${NC}\n${output}"
     exit 1
   fi
 
-  if echo "$output" | jq '. == []'; then
+  local is_json_empty
+  is_json_empty=$(echo "$output" | jq '. == []')
+  if [[ "$is_json_empty" == true ]]; then
     echo -e "${YELLOW}⚠️ Argo Application ${RELEASE_NAME} not found in namespace ${APPLICATION_NAMESPACE}. First deploy.${NC}"
     echo -e "${GREEN}🚀 Proceeding with the rollout.${NC}"
     exit 0

--- a/src/scripts/argo_app_previous_status.sh
+++ b/src/scripts/argo_app_previous_status.sh
@@ -67,6 +67,8 @@ function print_header() {
   echo "============================================================="
 }
 
+# We use 'argocd app list' to check if the application exists. 
+# We cannot use 'argocd app get' because it fails with PermissionDenied when the application is not found (masking the actual error).
 function validate_app_exists() {
   local output status
 

--- a/src/scripts/argo_cli_common.sh
+++ b/src/scripts/argo_cli_common.sh
@@ -4,6 +4,7 @@
 # argo_cli_common.sh
 #
 # Utility functions for preparing and cleaning up the ArgoCD CLI environment.
+# Every command redirects stdout and stderr to null, to avoid adding extra output to the result of the command.
 # This script is intended to be sourced from other scripts.
 #
 # Usage:
@@ -20,7 +21,6 @@
 
 # Colors for output
 RED="\033[0;31m"
-GREEN="\033[0;32m"
 NC="\033[0m" # No Color
 
 # Sets the kubectl context to the specified namespace and logs in to ArgoCD CLI.
@@ -28,20 +28,19 @@ NC="\033[0m" # No Color
 #   $1 - Namespace to set in the kubectl context.
 function set_argocd_cli() {
   local namespace="$1"
-  if ! kubectl config set-context --current --namespace="${namespace}"; then
+  if ! kubectl config set-context --current --namespace="${namespace}" >/dev/null 2>&1; then
     echo -e "${RED}❌ Failed to set kubectl context to namespace '${namespace}'${NC}"
     return 1
   fi
-  if ! argocd login cd.argoproj.io --core; then
+  if ! argocd login cd.argoproj.io --core >/dev/null 2>&1; then
     echo -e "${RED}❌ Failed to login to ArgoCD CLI in namespace '${namespace}'${NC}"
     return 1
   fi
-  echo -e "${GREEN}✅ ArgoCD CLI prepared for namespace '${namespace}'.${NC}"
 }
 
 # Resets the kubectl context to the default namespace.
 function unset_argocd_cli() {
-  if ! kubectl config set-context --current --namespace="default"; then
+  if ! kubectl config set-context --current --namespace="default" >/dev/null 2>&1; then
     echo -e "${RED}❌ Failed to reset kubectl context to default namespace.${NC}"
     return 1
   fi 


### PR DESCRIPTION
## Why? 🤔

For first deployments in ArgoCD, the check is failing because application doesn’t exists.

## What? :page_with_curl:

Add application existence validation in ArgoCD script
- Introduced `validate_app_exists` function to check if the specified ArgoCD application exists before proceeding with the rollout.
- Added error handling for unexpected failures, empty outputs, and invalid JSON responses from the ArgoCD CLI.

## Additional Links 🔗

[BAC-446](https://tiendanube.atlassian.net/browse/BAC-446)



[BAC-446]: https://tiendanube.atlassian.net/browse/BAC-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added pre-flight validation of required environment settings with clearer exit behavior.
  - Added explicit handling for first-time deployments when the Argo CD application does not yet exist.
  - Reworked status polling to use full application status and perform early validation before polling.

- Bug Fixes
  - Prevents unexpected failures by validating inputs and confirming app existence prior to polling.
  - Improves robustness of Argo CD query handling and JSON parsing.

- Chores
  - Quieted CLI output during setup/teardown and removed redundant success messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->