### PR TITLE
[BAC-450] Restore and improve support for x-nube-local-canary header …

### DIFF
--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -221,7 +221,7 @@ steps:
           --values $ARGO_APP_VALUE_FILE \
           --namespace << parameters.namespace >> \
           <<#parameters.args>><<parameters.args>><</parameters.args>> \
-          tiendanube-charts-preview/argocd-apps
+          << parameters.s3-chart-repo >>/argocd-apps
 
   - helm-status:
       release-name: << parameters.release-name >>-app

--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -189,6 +189,13 @@ steps:
             pruneLast: true
             validate: true
             replace: false
+            respectIgnoreDifferences: true
+
+        ignoreDifferences:
+          - group: networking.k8s.io
+            kind: Ingress
+            jqPathExpressions:
+              - ".spec.rules[]?.http.paths[]? | select(.backend.service.name == \"canary-header-route\")"
         EOF
         echo "------------------------------------------------------"
         echo "📄 ArgoCD Application manifest:"
@@ -215,7 +222,7 @@ steps:
           --values $ARGO_APP_VALUE_FILE \
           --namespace << parameters.namespace >> \
           <<#parameters.args>><<parameters.args>><</parameters.args>> \
-          << parameters.s3-chart-repo >>/argocd-apps
+          tiendanube-charts-preview/argocd-apps
 
   - helm-status:
       release-name: << parameters.release-name >>-app

--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -189,7 +189,6 @@ steps:
             pruneLast: true
             validate: true
             replace: false
-            respectIgnoreDifferences: true
 
         ignoreDifferences:
           - group: networking.k8s.io


### PR DESCRIPTION
…handling in ArgoCD + Rollouts

## Why? 🤔

We need this change because…

## What? :page_with_curl:

Please add a summary for this pull requests

## Additional Links 🔗

<!-- Add any relevant links here, eg. to other pull requests or Jira tickets.
NOTE: In case there aren't any, remove this section -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Configured ArgoCD to ignore specific differences on Ingress (canary-header-route backend path) to reduce noisy diffs during deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->