### PR TITLE
[BAC-438] Improve rollout status check

### DIFF
--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -181,6 +181,7 @@ steps:
 
         syncPolicy:
           automated:
+            enabled: true
             prune: true
             selfHeal: true
           syncOptions:

--- a/src/commands/argo-rollout-status.yml
+++ b/src/commands/argo-rollout-status.yml
@@ -17,4 +17,5 @@ steps:
         ROLLOUT_STATUS_TIMEOUT: << parameters.timeout >>
         ROLLOUT_STATUS_CHECK_INTERVAL: << parameters.check-interval >>
         ROLLOUT_STATUS_COMMON_SCRIPT: << include(scripts/argo_rollout_status_common.sh) >>
+        ARGO_CLI_COMMON_SCRIPT: << include(scripts/argo_cli_common.sh) >>
       command: << include(scripts/argo_rollout_status.sh) >>

--- a/src/scripts/argo_migration_workflow.sh
+++ b/src/scripts/argo_migration_workflow.sh
@@ -116,7 +116,9 @@ EOF
 # --- Handles feedback loop for migration phase ---
 function handle_feedback_decision() {
 
+  #shellcheck disable=SC1090
   source <(echo "$ARGO_CLI_COMMON_SCRIPT")
+  #shellcheck disable=SC1090
   source <(echo "$ROLLOUT_STATUS_COMMON_SCRIPT")
 
   # Validate required functions

--- a/src/scripts/argo_rollout_status.sh
+++ b/src/scripts/argo_rollout_status.sh
@@ -7,17 +7,43 @@
 #   NAMESPACE                     - The namespace to check
 #   ROLLOUT_STATUS_TIMEOUT        - Timeout in seconds
 #   ROLLOUT_STATUS_CHECK_INTERVAL - Interval between checks in seconds
+#   ROLLOUT_STATUS_COMMON_SCRIPT  - The script to source for reusable status check functions
+#   ARGO_CLI_COMMON_SCRIPT        - The script to source for reusable Argo CLI functions
 #
 # Returns:
 #   - Exit code 0 if rollout is Healthy or Completed, or if timeout is reached
 #   - Exit code 1 if rollout is Degraded, Error, or Aborted
 #   - Exit code 2 for script errors
+
+# Colors for output
+RED="\033[0;31m"
+NC="\033[0m" # No Color
+
 if [[ -z "${ROLLOUT_STATUS_COMMON_SCRIPT:-}" ]]; then
-  echo "Error: COMMON_SCRIPT is empty" >&2
+  echo -e "${RED}❌ Error: ROLLOUT_STATUS_COMMON_SCRIPT is empty${NC}" >&2
   exit 2
 fi
 
-source <(echo "$ROLLOUT_STATUS_COMMON_SCRIPT")
+if [[ -z "${ARGO_CLI_COMMON_SCRIPT:-}" ]]; then
+  echo -e "${RED}❌ Error: ARGO_CLI_COMMON_SCRIPT is empty${NC}" >&2
+  exit 2
+fi
+
+#shellcheck disable=SC1090
+source <(echo "${ROLLOUT_STATUS_COMMON_SCRIPT}")
+
+if ! declare -f "exec_rollout_status" > /dev/null; then
+  echo -e "${RED}❌ Error: exec_rollout_status function is not defined in subshell${NC}" >&2
+  exit 2
+fi
+
+#shellcheck disable=SC1090
+source <(echo "${ARGO_CLI_COMMON_SCRIPT}")
+
+if ! declare -f "with_argocd_cli" > /dev/null; then
+  echo -e "${RED}❌ Error: with_argocd_cli function is not defined in subshell${NC}" >&2
+  exit 2
+fi
 
 exec_rollout_status \
   --rollout-name "${ROLLOUT_NAME}" \

--- a/src/scripts/argo_rollout_status_common.sh
+++ b/src/scripts/argo_rollout_status_common.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Colors for output
-RED="\033[0;31m"
-GREEN="\033[0;32m"
-NC="\033[0m" # No Color
-
 # Script to check the status of an Argo Rollout.
 #
 # Usage:
@@ -14,6 +9,13 @@ NC="\033[0m" # No Color
 #   - Exit code 0 if rollout is Healthy or Completed, or if timeout is reached
 #   - Exit code 1 if rollout is Degraded, Error, or Aborted
 #   - Exit code 2 for script errors
+
+# Colors for output
+GREEN="\033[0;32m"
+BLUE="\033[0;34m"
+YELLOW="\033[1;33m"
+RED="\033[0;31m"
+NC="\033[0m" # No Color
 
 # Main entrypoint
 function exec_rollout_status() {
@@ -45,7 +47,8 @@ function exec_rollout_status() {
     local status="$1"
     local message="$2"
     local color="${RED}"
-    if [[ "$status" == "Healthy" || "$status" == "Completed" ]]; then
+
+    if [[ "$status" =~ ^(Healthy|Completed)$ ]]; then
       color="${GREEN}"
     fi
     echo -e "${color}--------------------------------------------------------"
@@ -53,32 +56,89 @@ function exec_rollout_status() {
     echo -e "   - Status: ${status}${NC}"
   }
 
+  #shellcheck disable=SC2329
+  function rollout_is_auto_sync_disabled() {
+    local sync_status="$1"
+    local auto_sync_status="$2"
+    local auto_sync_self_heal="$3"
+    local auto_sync_prune="$4"
+
+    # If at least one of the `syncPolicy.automated.[enabled|selfHeal|prune]` fields is disabled, this function returns true.
+    # $auto_sync_status == "false" is currently not used because it's not consistent throughout every ArgoCD Application JSON response.
+    { 
+      [[ $sync_status == "OutOfSync" ]] &&
+      [[ $auto_sync_self_heal == "false" || $auto_sync_prune == "false" ]]
+    }
+  }
+
+  #shellcheck disable=SC2329
+  function rollout_is_progressing() {
+    local rollout_status="$1"
+    local sync_status="$2"
+    local health_status="$3"
+    local operation_phase="$4"
+
+    {
+      [[ $rollout_status =~ ^(Progressing|Paused)$ ]] ||
+      [[ $operation_phase == "Running" ]] ||
+      [[ $health_status =~ ^(Progressing|Suspended|Missing)$ ]]
+    }
+  }
+
   # Main status check loop
   #shellcheck disable=SC2329
   function check_rollout_status() {
+    local kubectl_output argocd_output rollout_status sync_status health_status operation_phase auto_sync_status
     local i=1
+
     while true; do
-      echo "========================================================"
-      echo "🔍 Checking Rollout status (attempt $i)..."
-      output=$(kubectl argo rollouts get rollout "${rollout_name}" --namespace "${namespace}")
-      echo "$output"
-      status=$(echo "$output" | grep "^Status:" | awk '{print $3}')
-      case "$status" in
-        Healthy|Completed)
-          print_rollout_status_result "$status" "✅ Rollout is $status."
-          return 0
-          ;;
-        Degraded|Error|Aborted)
-          print_rollout_status_result "$status" "❌ Rollout status is $status. Exiting with failure."
-          return 1
-          ;;
-        Progressing|Paused)
-          echo "⏳ Rollout status is $status. Waiting..."
-          ;;
-        *)
-          echo "❓ Unknown status: $status. Waiting..."
-          ;;
-      esac
+      echo "============================================================="
+      echo "🔍 Checking Rollout / Application status (attempt $i)..."
+      # Get kubectl rollout status
+      kubectl_output=$(kubectl argo rollouts get rollout "${rollout_name}" --namespace "${namespace}")
+      echo "$kubectl_output"
+      rollout_status=$(echo "$kubectl_output" | grep "^Status:" | awk '{print $3}')
+
+      # Get application status
+      argocd_output=$(with_argocd_cli --namespace "${APPLICATION_NAMESPACE}" -- argocd app get "${rollout_name}" --output json)
+      operation_phase=$(echo "$argocd_output" | jq -r '.status.operationState.phase // "None"')
+      sync_status=$(echo "$argocd_output" | jq -r '.status.sync.status // "Unknown"')
+      health_status=$(echo "$argocd_output" | jq -r '.status.health.status // "Unknown"')
+      auto_sync_status=$(echo "$argocd_output" | jq -r '.spec.syncPolicy.automated.enabled // "false"')
+      auto_sync_self_heal=$(echo "$argocd_output" | jq -r '.spec.syncPolicy.automated.selfHeal // "false"')
+      auto_sync_prune=$(echo "$argocd_output" | jq -r '.spec.syncPolicy.automated.prune // "false"')
+
+      if rollout_is_progressing "$rollout_status" "$sync_status" "$health_status" "$operation_phase"; then
+        echo -e "${BLUE}⏳ Waiting... Rollout status is [$rollout_status].${NC}"
+        echo -e "${BLUE}Application Sync status [$sync_status]; Health status [$health_status]; Operation phase [$operation_phase].${NC}"
+      elif rollout_is_auto_sync_disabled "$sync_status" "$auto_sync_status" "$auto_sync_self_heal" "$auto_sync_prune"; then
+        echo "**********************************************************************"
+        echo "$argocd_output" | jq -r '.spec.syncPolicy'
+        echo "**********************************************************************"
+        echo -e "${YELLOW}--------------------------------------------------------"
+        echo -e "${YELLOW}⚠️ WARNING: Auto sync is disabled${NC}"
+        echo -e "${YELLOW}You must visit the ArgoCD UI to enable this feature in order to apply the already launched rollout.${NC}"
+        echo -e "${YELLOW}Pay special attention to activating these TWO fields:${NC}"
+        echo -e "${YELLOW} - Prune${NC}"
+        echo -e "${YELLOW} - Self Heal${NC}"
+        echo -e "${YELLOW}--------------------------------------------------------${NC}"
+      else
+        case "$rollout_status" in
+          Healthy|Completed)
+            print_rollout_status_result "$rollout_status" "✅ Rollout is $rollout_status."
+            return 0
+            ;;
+          Degraded|Error|Aborted)
+            print_rollout_status_result "$rollout_status" "❌ Rollout status is $rollout_status. Exiting with failure."
+            return 1
+            ;;
+          *)
+            echo -e "${YELLOW}❓ Unknown status: [$rollout_status]. Waiting...${NC}"
+            echo -e "${YELLOW}Application Sync status [$sync_status]; Health status [$health_status]; Operation phase [$operation_phase].${NC}"
+            ;;
+        esac
+      fi
+
       i=$((i+1))
       sleep "${rollout_status_check_interval}"
     done
@@ -101,10 +161,13 @@ function exec_rollout_status() {
 
   # Export variables needed by the subshell invoked by timeout.
   export rollout_name namespace rollout_status_timeout rollout_status_check_interval
+  export GREEN BLUE YELLOW RED NC
 
   local timeout_result=0
   timeout "${rollout_status_timeout}" bash -o pipefail -c "$(cat <<EOF
-  $(declare -f check_rollout_status print_rollout_status_result)
+  $(declare -f print_rollout_status_result rollout_is_progressing rollout_is_auto_sync_disabled)
+  $(declare -f with_argocd_cli set_argocd_cli unset_argocd_cli is_argocd_logged_in is_kubectl_namespace_set)
+  $(declare -f check_rollout_status)
   check_rollout_status
 EOF
 )" || timeout_result=$?


### PR DESCRIPTION
## Why? 🤔

Currently the rollout status only uses `kubectl` CLI and in many situations it detects `Healthy` status and stops, while actually the operation is in progress or it wasn’t even started.

## What? :page_with_curl:

Improve how ORB checks for Rollout status by combine current `kubectl` results with `argocd` CLI.
This allow the tool to detect operations in progress, rollouts suspended and many new scenarios.

## Additional Links 🔗

[BAC-438](https://tiendanube.atlassian.net/browse/BAC-438)

