### PR TITLE
BAC-492 - Prevent Rollout From Losing spec.replicas During ArgoCD Syn…

### DIFF
--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -202,6 +202,11 @@ steps:
             kind: ServiceAccount
             jqPathExpressions:
               - ".metadata.annotations[\"eks.amazonaws.com/role-arn\"]"
+          # Ignore differences in the Rollout replicas as it is managed by HPA when it is enabled
+          - group: argoproj.io
+            kind: Rollout
+            jqPathExpressions:
+              - ". | select(.metadata.annotations[\"tiendanube.com/hpa-enabled\"] == \"true\") | .spec.replicas"
         EOF
         echo "------------------------------------------------------"
         echo "📄 ArgoCD Application manifest:"


### PR DESCRIPTION
…c When Re-enabling HPA

## Why? 🤔

We need this change because…

## What? :page_with_curl:

Please add a summary for this pull requests

## Additional Links 🔗

<!-- Add any relevant links here, eg. to other pull requests or Jira tickets.
NOTE: In case there aren't any, remove this section -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated preparation step to handle HPA-related transitions before application syncs.

* **Bug Fixes**
  * Improved ArgoCD synchronization stability for autoscaled applications by removing stale replica configuration that could interfere with HPA/rollout transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->