### PR TITLE
BAC-464 - Auto-detect chart-version based on cluster-name

### DIFF
--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -166,7 +166,7 @@ steps:
           - path: microservices-v8
             name: main-helm-chart
             repoURL: https://github.com/TiendaNube/helm-charts
-            targetRevision: << parameters.chart-version >>
+            targetRevision: ${CHART_VERSION}
             helm:
               valueFiles:
                 - "\$values/<< parameters.values-file >>"$ADDITIONAL_VALUE_FILES

--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -35,7 +35,10 @@ parameters:
   old-school-chart-file:
     description: The file name of the chart used before migrating
     type: string
-  # Parameters for ArgoCD Application migration
+  chart-version:
+    description: Version/branch of the Helm chart to use
+    type: string
+    default: master
 
 steps:
   - run:
@@ -163,7 +166,7 @@ steps:
           - path: microservices-v8
             name: main-helm-chart
             repoURL: https://github.com/TiendaNube/helm-charts
-            targetRevision: master
+            targetRevision: << parameters.chart-version >>
             helm:
               valueFiles:
                 - "\$values/<< parameters.values-file >>"$ADDITIONAL_VALUE_FILES

--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -137,11 +137,23 @@ steps:
   - run:
       name: Create ArgoCD Application manifest
       command: |
+        # Compute CHART_VERSION from parameter or auto-detect from cluster
+        USER_CHART_VERSION="<< parameters.chart-version >>"
+        if [[ -n "$USER_CHART_VERSION" ]]; then
+          CHART_VERSION="$USER_CHART_VERSION"
+        elif [[ "$PROFILE_NAME" == *"staging"* ]]; then
+          CHART_VERSION="staging"
+        else
+          CHART_VERSION="master"
+        fi
+        # Set up directories and file paths
         ARGO_PARAMETERS_DIR=/tmp/argo-parameters
         ARGO_APP_VALUE_FILE="$ARGO_PARAMETERS_DIR/argocd-app-values.yaml"
         ARGO_PARAMETERS_FILE="$ARGO_PARAMETERS_DIR/parameters.yaml"
+        # Load and indent parameters from previous step
         PARAMETERS=$(cat "$ARGO_PARAMETERS_FILE")
         PARAMETERS_INDENTED=$(echo "$PARAMETERS" | awk 'NR==1{print $0; next} {print "      "$0}')
+        # Extract additional value files from helm args
         HELM_VALUES_FILES='<< parameters.args >>'
         VALUES_FILES=()
         while [[ "$HELM_VALUES_FILES" =~ --values[[:space:]]+([^[:space:]\\]+) ]]; do
@@ -154,6 +166,7 @@ steps:
             ADDITIONAL_VALUE_FILES+=$'\n'"        - \"\$values/${values_file}\""
           done
         fi
+        # Generate ArgoCD Application manifest
         cat \<< EOF > $ARGO_APP_VALUE_FILE
         argocd:
           namespace: argocd
@@ -206,6 +219,7 @@ steps:
             jqPathExpressions:
               - ".metadata.annotations[\"eks.amazonaws.com/role-arn\"]"
         EOF
+        # Print generated manifest
         echo "------------------------------------------------------"
         echo "📄 ArgoCD Application manifest:"
         echo "------------------------------------------------------"

--- a/src/jobs/argo-deploy.yml
+++ b/src/jobs/argo-deploy.yml
@@ -119,19 +119,6 @@ steps:
         echo "export REPOSITORY_HTTP_URL=$REPOSITORY_HTTP_URL" | tee -a $BASH_ENV
         echo "export HELM_DETECTION_DIR=/tmp/helm-detection" | tee -a $BASH_ENV
 
-        # Compute CHART_VERSION: use user-provided value, or infer from cluster-name
-        USER_CHART_VERSION="<< parameters.chart-version >>"
-        CLUSTER_NAME="<< parameters.cluster-name >>"
-        if [[ -n "$USER_CHART_VERSION" ]]; then
-          CHART_VERSION="$USER_CHART_VERSION"
-        elif [[ "$CLUSTER_NAME" == *"staging"* ]]; then
-          CHART_VERSION="staging"
-        else
-          CHART_VERSION="master"
-        fi
-        echo "export CHART_VERSION=$CHART_VERSION" | tee -a $BASH_ENV
-        echo "📦 Chart version: $CHART_VERSION"
-
   - when:
       condition: << parameters.checkout >>
       steps:

--- a/src/jobs/argo-deploy.yml
+++ b/src/jobs/argo-deploy.yml
@@ -20,6 +20,10 @@ parameters:
   chart:
     description: Chart that will be installed
     type: string
+  chart-version:
+    description: Version/branch of the Helm chart to use
+    type: string
+    default: master
   release-name:
     description: Helm release name
     type: string
@@ -191,6 +195,7 @@ steps:
       rollout-status-timeout: << parameters.rollout-status-timeout >>
       project: << parameters.project >>
       old-school-chart-file: /tmp/helm-detection/chart_name
+      chart-version: << parameters.chart-version >>
 
   - when:
       condition: << parameters.argocd-migration-workflow-enabled >>

--- a/src/jobs/argo-deploy.yml
+++ b/src/jobs/argo-deploy.yml
@@ -21,9 +21,9 @@ parameters:
     description: Chart that will be installed
     type: string
   chart-version:
-    description: Version/branch of the Helm chart to use
+    description: Version/branch of the Helm chart to use. If not provided, defaults to 'staging' for staging clusters and 'master' for production clusters.
     type: string
-    default: master
+    default: ""
   release-name:
     description: Helm release name
     type: string
@@ -118,6 +118,19 @@ steps:
         echo "export APPLICATION_NAMESPACE=argocd" | tee -a $BASH_ENV
         echo "export REPOSITORY_HTTP_URL=$REPOSITORY_HTTP_URL" | tee -a $BASH_ENV
         echo "export HELM_DETECTION_DIR=/tmp/helm-detection" | tee -a $BASH_ENV
+
+        # Compute CHART_VERSION: use user-provided value, or infer from cluster-name
+        USER_CHART_VERSION="<< parameters.chart-version >>"
+        CLUSTER_NAME="<< parameters.cluster-name >>"
+        if [[ -n "$USER_CHART_VERSION" ]]; then
+          CHART_VERSION="$USER_CHART_VERSION"
+        elif [[ "$CLUSTER_NAME" == *"staging"* ]]; then
+          CHART_VERSION="staging"
+        else
+          CHART_VERSION="master"
+        fi
+        echo "export CHART_VERSION=$CHART_VERSION" | tee -a $BASH_ENV
+        echo "📦 Chart version: $CHART_VERSION"
 
   - when:
       condition: << parameters.checkout >>

--- a/src/scripts/argo_rollout_status_common.sh
+++ b/src/scripts/argo_rollout_status_common.sh
@@ -152,14 +152,6 @@ function exec_rollout_status() {
       }
 
       # Wait for rollout to exist before checking status
-      # Skip rollout validation when migration phase is "safe" (no rollout exists yet)
-      if [[ "${CANARY_MIGRATION_PHASE:-}" == "safe" ]]; then
-        echo -e "${GREEN}--------------------------------------------------------"
-        echo -e "✅ Migration phase is 'safe'. Skipping rollout validation."
-        echo -e "--------------------------------------------------------${NC}"
-        return 0
-      fi
-
       local rollout_exists_status
       does_argocd_rollout_exist "${namespace}" "${rollout_name}"; rollout_exists_status=$?
       [[ $rollout_exists_status -eq 2 ]] && return 1
@@ -235,7 +227,6 @@ function exec_rollout_status() {
     echo "   - Namespace: ${namespace}"
     echo "   - Timeout: ${rollout_status_timeout}"
     echo "   - Check interval: ${rollout_status_check_interval}s"
-    echo "   - Migration phase: ${CANARY_MIGRATION_PHASE:-unknown}"
     echo "--------------------------------------------------------"
   }
 
@@ -246,7 +237,6 @@ function exec_rollout_status() {
   # Export variables needed by the subshell invoked by timeout.
   export rollout_name namespace project_repo_name rollout_status_timeout rollout_status_check_interval
   export GREEN BLUE YELLOW RED NC
-  export CANARY_MIGRATION_PHASE
 
   local timeout_result=0
   timeout "${rollout_status_timeout}" bash -o pipefail -c "$(cat <<EOF


### PR DESCRIPTION
## Summary
- Auto-detects `chart-version` based on `cluster-name` when not explicitly provided
- Uses `staging` branch for staging clusters
- Uses `master` branch for production clusters

## Jira Ticket
https://tiendanube.atlassian.net/browse/BAC-464

## Test plan
- [ ] Deploy to a staging cluster without specifying `chart-version` → should use `staging`
- [ ] Deploy to a production cluster without specifying `chart-version` → should use `master`
- [ ] Deploy with explicit `chart-version` parameter → should use the provided value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable Helm chart version/branch parameter for deployments; users can specify a version, have it inferred for staging, or use the default.
  * Deployment flow now uses the resolved chart version when creating/updating applications.
  * Deployment logs include the resolved chart version for improved transparency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->