### PR TITLE
[BAC-492] Fix fixed replicas to HPA transition

### DIFF
--- a/src/commands/argo-deploy-application.yml
+++ b/src/commands/argo-deploy-application.yml
@@ -202,6 +202,11 @@ steps:
             kind: ServiceAccount
             jqPathExpressions:
               - ".metadata.annotations[\"eks.amazonaws.com/role-arn\"]"
+          # Ignore differences in the Rollout replicas as it is managed by HPA when it is enabled
+          - group: argoproj.io
+            kind: Rollout
+            jqPathExpressions:
+              - ". | select(.metadata.annotations[\"tiendanube.com/hpa-enabled\"] == \"true\") | .spec.replicas"
         EOF
         echo "------------------------------------------------------"
         echo "📄 ArgoCD Application manifest:"


### PR DESCRIPTION
## Why? 🤔

When a service transitions from fixed `spec.replicas` to _HPA-managed_ autoscaling, _Kubernetes_ defaults the replica count to 1, causing partial downtime for services that cannot handle their workload with a single pod.

This happens because of how `kubectl apply` performs a _three-way_ merge: it compares the previous manifest (stored in the `last-applied-configuration` annotation), the new desired manifest, and the live state. When `spec.replicas` was previously declared and is now omitted (because _HPA_ should manage it), the _three-way_ merge interprets this as an intentional deletion and removes the field — causing _Kubernetes_ to default to 1 replica instead of preserving the current count.

## What? 📄

Adds a conditional `ignoreDifferences` entry to the generated _ArgoCD_ `Application` manifest for the `Rollout` resource when `autoscaling.enabled: true` is detected in the user's values file:

```yaml
ignoreDifferences:
  - group: argoproj.io
    kind: Rollout
    jqPathExpressions:
      - ".spec.replicas"
```

### Why this works

The `argocd-apps` _Helm_ chart auto-enables `RespectIgnoreDifferences=true` in `syncOptions` whenever the `ignoreDifferences` list is non-empty. Because that list already contained rules for `Ingress` and `ServiceAccount` before this PR, `RespectIgnoreDifferences` was already active for every `Application` generated by this orb. What this PR actually changes is **extending the existing `ignoreDifferences` list** with a new entry that targets `Rollout.spec.replicas` when HPA is enabled.

With `RespectIgnoreDifferences=true`, during sync _ArgoCD_ injects the live value of ignored fields into the desired manifest before applying. For the new rule, that means:
- Desired (from _Helm_ template): `spec.replicas` absent
- Live: `spec.replicas` preserved (set by previous deploy or HPA)
- _ArgoCD_ injects the live value into desired before `kubectl apply`
- Three-way merge sees "was present, still present" → no deletion
- The `Rollout` controller uses the live value when creating new `ReplicaSets`

The rule is added conditionally so fixed-replica deployments (where the _Helm_ template sets `spec.replicas` explicitly) continue to be enforced by _ArgoCD_.

## Alternatives explored 🔍

Kept here as historical record in case someone hits similar symptoms in the future and revisits the trade-offs.

### 1. Ignore the spec.replicas based on `tiendanube.com/hpa-enabled` annotation

See [TiendaNube/helm-charts#201](https://github.com/TiendaNube/helm-charts/pull/201).

**Approach:** Modify the `microservices-v8` `Rollout` template so that `spec.replicas` is always emitted, even when HPA is enabled, using an interim midpoint value and an `tiendanube.com/hpa-enabled` annotation:

```yaml
metadata:
  annotations:
    tiendanube.com/hpa-enabled: {{ .Values.autoscaling.enabled | quote }}
spec:
  {{- if .Values.autoscaling.enabled }}
  replicas: {{ add $min (div (sub $max $min) 2) }}  # midpoint
  {{- else }}
  replicas: {{ .Values.deployment.replicaCount }}
  {{- end }}
```

**Why it was discarded:** During testing we observed that the `Rollout` still ended up at 1 replica on the HPA transition, even with `spec.replicas` present in the rendered template. The suspected culprit is the `tiendanube.com/hpa-enabled` annotation interacting with an admission/mutation layer that strips `spec.replicas` when the annotation flips to `"true"` — not the midpoint calculation itself, which by itself would have been sufficient to prevent the default-to-1.

### 2. Pre-deploy script cleaning `last-applied-configuration` annotation

**Approach:** A `bash` script (`argo_hpa_transition.sh`) invoked before `helm upgrade` that reads the `Rollout`'s `kubectl.kubernetes.io/last-applied-configuration` annotation, strips `.spec.replicas` from it via `jq`, and writes it back via `kubectl annotate`. With the field absent from the "previous" manifest, the three-way merge sees "was absent, still absent" and leaves the live value alone.

This was the original approach taken in this PR, analogous to https://github.com/max0ne/helm-omit-replicas-for-hpa.

**Why it was discarded in favor of `ignoreDifferences`:**

| | Pre-deploy script | `ignoreDifferences` (implemented) |
|---|---|---|
| Runtime dependencies | `kubectl`, `jq`, RBAC to patch annotations | None beyond _ArgoCD_ itself |
| Direct mutation of live resources | Yes (patches the annotation) | No |
| New failure modes | Auth/RBAC/network errors on the extra `kubectl` calls | None |
| Reversibility (HPA → fixed) | Needs manual thought | Automatic (conditional removes the rule) |
| Lines of code | ~90 (bash script) | ~10 (YAML + shell conditional in the orb) |

Functionally equivalent for the transition case, but the `ignoreDifferences` approach has fewer moving parts and works at the correct layer (_ArgoCD_'s diff engine via `RespectIgnoreDifferences`) rather than side-stepping it.

## Validation ✅

Three scenarios verified against fresh test services in `argocd-rollouts-it`:

1. **Fixed replicas → HPA (the original bug):** transitioning from `replicaCount: 3` to `autoscaling.enabled: true` preserved the live replica count. Observed sequence: `3 (fixed) → 3 (HPA just enabled) → 4 (HPA scaled up by memory)`. The new `ReplicaSet` was born with the live count instead of defaulting to 1.
2. **HPA → fixed replicas:** transitioning the other way went `2 (HPA minReplicas) → 3 (fixed replicaCount)` directly, without dropping to 1 or taking an interim value.
3. **Non-replicas change during HPA active:** updating a `Rollout` field other than `spec.replicas` (e.g. a pod label) went through normally. The `Rollout` progressed to a new revision, `spec.replicas` stayed at the live value, and the only writer to `spec.replicas` seen in events was `horizontal-pod-autoscaler` — _ArgoCD_ did not appear as an actor. Confirms `applyOutOfSyncOnly: true` interacts correctly with the new `ignoreDifferences` rule.

## Additional Links 🔗

[BAC-492](https://tiendanube.atlassian.net/browse/BAC-492) · Related: [TiendaNube/helm-charts#201](https://github.com/TiendaNube/helm-charts/pull/201)

[BAC-492]: https://tiendanube.atlassian.net/browse/BAC-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
